### PR TITLE
Proof of Concept: Find usages of `IStringLocalizer<T>` by type, not by field/property name.

### DIFF
--- a/src/OrchardCoreContrib.PoExtractor.DotNet.CS/OrchardCoreContrib.PoExtractor.DotNet.CS.csproj
+++ b/src/OrchardCoreContrib.PoExtractor.DotNet.CS/OrchardCoreContrib.PoExtractor.DotNet.CS.csproj
@@ -7,4 +7,8 @@
   <ItemGroup>
     <ProjectReference Include="..\OrchardCoreContrib.PoExtractor.DotNet\OrchardCoreContrib.PoExtractor.DotNet.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.4" />
+  </ItemGroup>
 </Project>

--- a/src/OrchardCoreContrib.PoExtractor.DotNet.CS/StringLocalizerOfTExtractor.cs
+++ b/src/OrchardCoreContrib.PoExtractor.DotNet.CS/StringLocalizerOfTExtractor.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Linq;
+using Microsoft.Extensions.Localization;
+
+namespace OrchardCoreContrib.PoExtractor.DotNet.CS;
+
+/// <summary>
+/// Extracts <see cref="LocalizableStringOccurence"/> with the singular text from the C# AST node
+/// </summary>
+/// <remarks>
+/// The localizable string is identified by the name convention - T["TEXT TO TRANSLATE"]
+/// </remarks>
+public class StringLocalizerOfTExtractor : LocalizableStringExtractor<SyntaxNode>
+{
+    private readonly SemanticModel semanticModel;
+    private readonly INamedTypeSymbol stringLocalizerType;
+
+    /// <summary>
+    /// Creates a new instance of a <see cref="SingularStringExtractor"/>.
+    /// </summary>
+    /// <param name="metadataProvider">The <see cref="IMetadataProvider{TNode}"/>.</param>
+    public StringLocalizerOfTExtractor(
+        IMetadataProvider<SyntaxNode> metadataProvider,
+        SemanticModel semanticModel) : base(metadataProvider)
+    {
+        this.semanticModel = semanticModel;
+        stringLocalizerType = semanticModel.Compilation.GetTypeByMetadataName(typeof(IStringLocalizer<>).FullName!);
+    }
+
+    /// <inheritdoc/>
+    public override bool TryExtract(SyntaxNode node, out LocalizableStringOccurence result)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+
+        result = null;
+        
+        if (node is ElementAccessExpressionSyntax accessor &&
+            semanticModel.GetTypeInfo(accessor.Expression).Type is INamedTypeSymbol accessedType &&
+            stringLocalizerType.Equals(accessedType.OriginalDefinition, SymbolEqualityComparer.Default))
+        {
+            var resourceType = accessedType.TypeArguments.Single();
+            
+            if(accessor.ArgumentList.Arguments[0].Expression is LiteralExpressionSyntax literal &&
+               literal.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                result = CreateLocalizedString(literal.Token.ValueText, null, node);
+                return true;
+            }
+
+            var location = MetadataProvider.GetLocation(node);
+            throw new Exception(
+                $"Detected access to {nameof(IStringLocalizer<object>)}[] where the first argument is not a string literal at {location.SourceFile}:{location.SourceFileLine}.");
+        }
+
+        return false;
+    }
+
+}

--- a/src/OrchardCoreContrib.PoExtractor.Razor/OrchardCoreContrib.PoExtractor.Razor.csproj
+++ b/src/OrchardCoreContrib.PoExtractor.Razor/OrchardCoreContrib.PoExtractor.Razor.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.27" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OrchardCoreContrib.PoExtractor.DotNet.CS\OrchardCoreContrib.PoExtractor.DotNet.CS.csproj" />


### PR DESCRIPTION
find StringLocalizer calls not by name convention but by type.

TODO: consider trying to simplify by:
- compiling the whole project, then maybe we don't need any special case handling for razor templates because they're already compiled? --> see https://github.com/dotnet/roslyn/discussions/56009#discussioncomment-1256069 and https://stackoverflow.com/questions/13280008/how-do-i-compile-a-c-sharp-solution-with-roslyn
- switch to using Mono.Cecil and analyze the binary output instead of the source. This contains all relevant information already, and thus may be faster - but does not work when the source doesn't compile...